### PR TITLE
fix(cd): handle no entry

### DIFF
--- a/app/cmd-cd/route.js
+++ b/app/cmd-cd/route.js
@@ -12,7 +12,7 @@ export default Route.extend({
         let cdTarget = rawInputArgs;
 
         // cd into current directory is noop
-        if (cdTarget === '.' || cdTarget === './') {
+        if ( !cdTarget || cdTarget === '.' || cdTarget === './') {
             return;
         }
 


### PR DESCRIPTION
fix cd bug where it would crash if you didn't enter anything other than the `cd` command